### PR TITLE
public iterator for VecSet

### DIFF
--- a/src/vec_set.rs
+++ b/src/vec_set.rs
@@ -2,9 +2,11 @@ use crate::merge_state::InPlaceMergeState;
 use crate::{
     binary_merge::{EarlyOut, MergeOperation},
     dedup::sort_and_dedup,
-    iterators::VecSetIter,
     merge_state::{BoolOpMergeState, MergeStateMut, SmallVecMergeState},
 };
+
+pub use crate::iterators::VecSetIter;
+
 #[cfg(feature = "serde")]
 use core::marker::PhantomData;
 use core::{


### PR DESCRIPTION
I'm trying vec-collections for a library I'm writing, and I'm very happy with the results (basically a [two-lines change](https://github.com/dib-lab/sourmash/pull/1238/commits/36b30d32dd43b8d449b64e4f0fd5c2e7a6dfb5da#diff-233f06d960c3779edc1471ad2c2ec590d7f8359adbe14062ac147ec4b19f7fc5)). My only issue was with reusing the [`VecSetIter` iterator](https://github.com/dib-lab/sourmash/pull/1238/commits/36b30d32dd43b8d449b64e4f0fd5c2e7a6dfb5da#diff-233f06d960c3779edc1471ad2c2ec590d7f8359adbe14062ac147ec4b19f7fc5R460), since it is not available in the public API.

This PR contains the change I did for my fork, would you consider adding it to vec-collections?

Thanks!